### PR TITLE
Remove "--" from CMD in Dockerfile

### DIFF
--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -8,7 +8,7 @@ RUN addgroup -S salt && adduser -SD -G salt salt && \
     chgrp -R salt /etc/pki /etc/salt /var/cache/salt /var/log/salt /var/run/salt
 
 ENTRYPOINT ["/usr/bin/dumb-init"]
-CMD ["--", "/usr/local/bin/saltinit"]
+CMD ["/usr/local/bin/saltinit"]
 ADD saltinit.py /usr/local/bin/saltinit
 EXPOSE 8000
 


### PR DESCRIPTION
"--" is not necessary because Docker takes care of it.

Test example:
```
docker run --rm -it saltstack/salt sh -c ls
bin    etc    lib    mnt    proc   run    srv    tmp    var
dev    home   media  opt    root   sbin   sys    usr
```

