### PR TITLE
Create /etc/salt/pki directory in image

### DIFF
--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -3,7 +3,7 @@ FROM alpine:latest
 RUN apk add --no-cache --update python3-dev gcc g++ autoconf make libffi-dev openssl-dev dumb-init py3-openssl
 
 RUN addgroup -g 450 -S salt && adduser -SD -G salt salt && \
-    mkdir -p /etc/pki /etc/salt/minion.d/ /etc/salt/master.d /etc/salt/proxy.d /var/cache/salt /var/log/salt /var/run/salt && \
+    mkdir -p /etc/pki /etc/salt/pki /etc/salt/minion.d/ /etc/salt/master.d /etc/salt/proxy.d /var/cache/salt /var/log/salt /var/run/salt && \
     chmod -R 2775 /etc/pki /etc/salt /var/cache/salt /var/log/salt /var/run/salt && \ 
     chgrp -R salt /etc/pki /etc/salt /var/cache/salt /var/log/salt /var/run/salt
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from saltdocker import SaltVersion
 
 @pytest.fixture
 def date():
-    return SaltVersion('2017.7.8').date
+    return SaltVersion.date()
 
 
 @pytest.fixture


### PR DESCRIPTION
If the /etc/salt/pki directory exists in the image, adding a
persistent volume (eg using --mount source=salt-pki,target=/etc/salt/pki)
will result in the newly created volume having the permissions from
the image copied to it, allowing the salt user to write to the pki
directory in the volume.