### PR TITLE
in saltinit, avoid writing to user.conf if it exists

### DIFF
--- a/saltinit.py
+++ b/saltinit.py
@@ -51,8 +51,9 @@ async def main():
         if "SALT_MASTER_CONFIG" in os.environ:
             with open("/etc/salt/master.d/master.conf", "w") as masterfile:
                 json.dump(json.loads(os.environ["SALT_MASTER_CONFIG"]), masterfile)
-        with open("/etc/salt/master.d/user.conf", "w") as userfile:
-            json.dump({"user": "salt"}, userfile)
+        if not os.path.exists("/etc/salt/master.d/user.conf"):
+            with open("/etc/salt/master.d/user.conf", "w") as userfile:
+                json.dump({"user": "salt"}, userfile)
         futures.append(await asyncio.create_subprocess_exec("salt-api"))
         futures.append(await asyncio.create_subprocess_exec("salt-master"))
 


### PR DESCRIPTION
Context: I'm trying to mount a Kubernetes ConfigMap [as a volume](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#add-configmap-data-to-a-volume) on `/etc/salt/master.d` inside the container. But this makes the directory unavoidably read-only due to kubernetes/kubernetes#62099, so I'm stuck with the following crash inside `saltinit`:

```
File "/usr/local/bin/saltinit", line 54, in main
    with open("/etc/salt/master.d/user.conf", "w") as userfile:
OSError: [Errno 30] Read-only file system: '/etc/salt/master.d/user.conf'
```

I can prevent the write to `api.conf` by providing my own definition for it inside the ConfigMap, and the write to `master.conf` by leaving `SALT_MASTER_CONFIG` unset. But there is no conditional guarding the write to `user.conf`, so I can't head off this particular crash (other than by configuring it as a minion or proxy, which is self-defeating). Do you think it's reasonable to add this conditional here?